### PR TITLE
Fixes Vue tip re: kebab-case warning

### DIFF
--- a/src/DragHtml.vue
+++ b/src/DragHtml.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<drag class="drag" :transferData="{ example: 'drag-html' }">
+		<drag class="drag" :transfer-data="{ example: 'drag-html' }">
 			drag
 			<div slot="image" class="drag-image">
 				<ul>


### PR DESCRIPTION
Using the `transferData` prop name throws a [Vue tip]` warning indicating kebab-casing is preferred. Changing to kebab-case prop naming does not impact the functionality but does remove the debug warning.